### PR TITLE
Add support for raising property change when destination field isn't owned by the class

### DIFF
--- a/ReactiveUI.Fody.Helpers/ReactiveDependencyAttribute.cs
+++ b/ReactiveUI.Fody.Helpers/ReactiveDependencyAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ReactiveUI.Fody.Helpers
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ReactiveDependencyAttribute : Attribute
+    {
+        private readonly string _targetName;
+
+        public ReactiveDependencyAttribute(string targetName)
+        {
+            _targetName = targetName;
+        }
+
+        /// <summary>
+        /// The name of the backing property
+        /// </summary>
+        public string Target => _targetName;
+
+        /// <summary>
+        /// Target property on the backing property
+        /// </summary>
+        public string TargetProperty { get; set; }
+    }
+}

--- a/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.projitems
+++ b/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.projitems
@@ -12,5 +12,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)ObservableAsPropertyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ObservableAsPropertyExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactiveAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReactiveDependencyAttribute.cs" />
   </ItemGroup>
 </Project>

--- a/ReactiveUI.Fody.Tests/FodyWeavers.xml
+++ b/ReactiveUI.Fody.Tests/FodyWeavers.xml
@@ -2,4 +2,5 @@
 <Weavers>
     <ObservableAsPropertyWeaver />
     <ReactiveUIPropertyWeaver />
+    <ReactiveDependencyPropertyWeaver />
 </Weavers>

--- a/ReactiveUI.Fody.Tests/ReactiveDependencyTests.cs
+++ b/ReactiveUI.Fody.Tests/ReactiveDependencyTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.ComponentModel;
+using NUnit.Framework;
+using ReactiveUI.Fody.Helpers;
+
+namespace ReactiveUI.Fody.Tests
+{
+    public class ReactiveDependencyTests
+    {
+        [Test]
+        public void IntPropertyOnWeavedFacadeReturnsBaseModelIntPropertyDefaultValueTest()
+        {
+            var model = new BaseModel();
+            var expectedResult = model.IntProperty;
+
+            var facade = new FacadeModel(model);
+
+            Assert.AreEqual(expectedResult, facade.IntProperty);
+        }
+
+        [Test]
+        public void AnotherStringPropertyOnFacadeReturnsBaseModelStringPropertyDefaultValueTest()
+        {
+            var model = new BaseModel();
+            var expectedResult = model.StringProperty;
+
+            var facade = new FacadeModel(model);
+
+            Assert.AreEqual(expectedResult, facade.AnotherStringProperty);
+        }
+
+        [Test]
+        public void SettingAnotherStringPropertyUpdatesTheDependencyStringProperty()
+        {
+            var expectedResult = "New String Value";
+            var facade = new FacadeModel(new BaseModel());
+
+            facade.AnotherStringProperty = expectedResult;
+
+            Assert.AreEqual(expectedResult, facade.Dependency.StringProperty);
+        }
+
+        [Test]
+        public void SettingFacadeIntPropertyUpdatesDependencyIntProperty()
+        {
+            var expectedResult = 999;
+            var facade = new FacadeModel(new BaseModel());
+
+            facade.IntProperty = expectedResult;
+
+            Assert.AreEqual(expectedResult, facade.Dependency.IntProperty);
+        }
+
+        [Test]
+        public void FacadeIntPropertyChangedEventFiresOnAssignementTest()
+        {
+            var expectedPropertyChanged = "IntProperty";
+            var resultPropertyChanged = string.Empty;
+
+            var facade = new FacadeModel(new BaseModel());
+
+            var obj = (INotifyPropertyChanged) facade;
+            obj.PropertyChanged += (sender, args) => resultPropertyChanged = args.PropertyName;
+
+            facade.IntProperty = 999;
+
+            Assert.AreEqual(expectedPropertyChanged, resultPropertyChanged);
+        }
+
+        [Test]
+        public void FacadeAnotherStringPropertyChangedEventFiresOnAssignementTest()
+        {
+            var expectedPropertyChanged = "AnotherStringProperty";
+            var resultPropertyChanged = string.Empty;
+
+            var facade = new FacadeModel(new BaseModel());
+
+            var obj = (INotifyPropertyChanged) facade;
+            obj.PropertyChanged += (sender, args) => resultPropertyChanged = args.PropertyName;
+
+            facade.AnotherStringProperty = "Some New Value";
+
+            Assert.AreEqual(expectedPropertyChanged, resultPropertyChanged);
+        }
+
+        [Test]
+        public void StringPropertyOnWeavedDecoratorReturnsBaseModelDefaultStringValue()
+        {
+            var model = new BaseModel();
+            var expectedResult = model.StringProperty;
+
+            var decorator = new DecoratorModel(model);
+
+            Assert.AreEqual(expectedResult, decorator.StringProperty);
+        }
+
+        [Test]
+        public void DecoratorStringPropertyRaisesPropertyChanged()
+        {
+            var expectedPropertyChanged = "StringProperty";
+            var resultPropertyChanged = string.Empty;
+
+            var decorator = new DecoratorModel(new BaseModel());
+
+            var obj = (INotifyPropertyChanged) decorator;
+            obj.PropertyChanged += (sender, args) => resultPropertyChanged = args.PropertyName;
+
+            decorator.StringProperty = "Some New Value";
+
+            Assert.AreEqual(expectedPropertyChanged, resultPropertyChanged);
+        }
+    }
+
+    public class BaseModel : ReactiveObject
+    {
+        public virtual int IntProperty { get; set; } = 5;
+        public virtual string StringProperty { get; set; } = "Initial Value";
+    }
+
+    public class FacadeModel : ReactiveObject
+    {
+        private BaseModel _dependency;
+
+        public FacadeModel()
+        {
+            _dependency = new BaseModel();
+        }
+
+        public FacadeModel(BaseModel dependency)
+        {
+            _dependency = dependency;
+        }
+
+        public BaseModel Dependency
+        {
+            get { return _dependency; }
+            private set { _dependency = value; }
+        }
+
+        // Property with the same name, will look for a like for like name on the named dependency
+        [ReactiveDependency(nameof(Dependency))]
+        public int IntProperty { get; set; }
+
+        // Property named differently to that on the dependency but still pass through value
+        [ReactiveDependency(nameof(Dependency), TargetProperty = "StringProperty")]
+        public string AnotherStringProperty { get; set; }
+    }
+
+    public class DecoratorModel : BaseModel
+    {
+        private readonly BaseModel _model;
+
+        // Testing ctor
+        public DecoratorModel()
+        {
+            _model = new BaseModel();
+        }
+
+        public DecoratorModel(BaseModel baseModel)
+        {
+            _model = baseModel;
+        }
+
+        [Reactive]
+        public string SomeCoolNewProperty { get; set; }
+
+        // Works with private fields
+        [ReactiveDependency(nameof(_model))]
+        public override string StringProperty { get; set; }
+
+        // Can't be attributed as has additional functionality in the decorated get
+        public override int IntProperty
+        {
+            get { return _model.IntProperty * 2; }
+            set
+            {
+                _model.IntProperty = value;
+                this.RaisePropertyChanged();
+            }
+        }
+    }
+}

--- a/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
+++ b/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Issues\Issue11Tests.cs" />
     <Compile Include="ObservableAsPropertyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReactiveDependencyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ReactiveUI.Fody/ModuleWeaver.cs
+++ b/ReactiveUI.Fody/ModuleWeaver.cs
@@ -29,6 +29,14 @@ namespace ReactiveUI.Fody
                 LogInfo = LogInfo
             };
             observableAsPropertyWeaver.Execute();
+
+            var reactiveDependencyWeaver = new ReactiveDependencyPropertyWeaver
+            {
+                ModuleDefinition = ModuleDefinition,
+                LogInfo = LogInfo,
+                LogError = LogError
+            };
+            reactiveDependencyWeaver.Execute();
         }
     }
 }

--- a/ReactiveUI.Fody/ReactiveDependencyPropertyWeaver.cs
+++ b/ReactiveUI.Fody/ReactiveDependencyPropertyWeaver.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
+
+namespace ReactiveUI.Fody
+{
+    public class ReactiveDependencyPropertyWeaver
+    {
+        public ModuleDefinition ModuleDefinition { get; set; }
+
+        // Will log an MessageImportance.High message to MSBuild. OPTIONAL
+        public Action<string> LogInfo { get; set; }
+
+        // Will log an error message to MSBuild. OPTIONAL
+        public Action<string> LogError { get; set; }
+
+        public void Execute()
+        {
+            var reactiveUI = ModuleDefinition.AssemblyReferences.Where(x => x.Name == "ReactiveUI").OrderByDescending(x => x.Version).FirstOrDefault();
+            if (reactiveUI == null)
+            {
+                LogInfo("Could not find assembly: ReactiveUI (" + string.Join(", ", ModuleDefinition.AssemblyReferences.Select(x => x.Name)) + ")");
+                return;
+            }
+            LogInfo($"{reactiveUI.Name} {reactiveUI.Version}");
+            var helpers = ModuleDefinition.AssemblyReferences.Where(x => x.Name == "ReactiveUI.Fody.Helpers").OrderByDescending(x => x.Version).FirstOrDefault();
+            if (helpers == null)
+            {
+                LogInfo("Could not find assembly: ReactiveUI.Fody.Helpers (" + string.Join(", ", ModuleDefinition.AssemblyReferences.Select(x => x.Name)) + ")");
+                return;
+            }
+            LogInfo($"{helpers.Name} {helpers.Version}");
+            var reactiveObject = new TypeReference("ReactiveUI", "IReactiveObject", ModuleDefinition, reactiveUI);
+
+            var targetTypes = ModuleDefinition.GetAllTypes().Where(x => x.BaseType != null && reactiveObject.IsAssignableFrom(x.BaseType)).ToArray();
+            var reactiveObjectExtensions = new TypeReference("ReactiveUI", "IReactiveObjectExtensions", ModuleDefinition, reactiveUI).Resolve();
+            if (reactiveObjectExtensions == null) throw new Exception("reactiveObjectExtensions is null");
+
+            var raisePropertyChangedMethod = ModuleDefinition.Import(reactiveObjectExtensions.Methods.Single(x => x.Name == "RaisePropertyChanged"));
+            if (raisePropertyChangedMethod == null) throw new Exception("raisePropertyChangedMethod is null");
+
+            var reactiveDependencyAttribute = ModuleDefinition.FindType("ReactiveUI.Fody.Helpers", "ReactiveDependencyAttribute", helpers);
+            if (reactiveDependencyAttribute == null) throw new Exception("reactiveDecoratorAttribute is null");
+
+            foreach (var targetType in targetTypes.Where(x => x.Properties.Any(y => y.IsDefined(reactiveDependencyAttribute))).ToArray())
+            {
+                foreach (var facadeProperty in targetType.Properties.Where(x => x.IsDefined(reactiveDependencyAttribute)).ToArray())
+                {
+                    // If the property already has a body then do not weave to prevent loss of instructions
+                    if (!facadeProperty.GetMethod.Body.Instructions.Any(x => x.Operand is FieldReference) || facadeProperty.GetMethod.Body.HasVariables)
+                    {
+                        LogError($"Property {facadeProperty.Name} is not an auto property and therefore not suitable for ReactiveDependency weaving");
+                        continue;
+                    }
+
+                    var attribute = facadeProperty.CustomAttributes.First(x => x.AttributeType.FullName == reactiveDependencyAttribute.FullName);
+                    
+                    var targetNamedArgument = attribute.ConstructorArguments.FirstOrDefault();
+                    var targetValue = targetNamedArgument.Value?.ToString();
+                    if (string.IsNullOrEmpty(targetValue))
+                    {
+                        LogError("No target property defined on the object");
+                        continue;
+                    }
+
+                    if (targetType.Properties.All(x => x.Name != targetValue) && targetType.Fields.All(x => x.Name != targetValue))
+                    {
+                        LogError($"dependency object property/field name '{targetValue}' not found on target type {targetType.Name}");
+                        continue;
+                    }
+
+                    var objPropertyTarget = targetType.Properties.FirstOrDefault(x => x.Name == targetValue);
+                    var objFieldTarget = targetType.Fields.FirstOrDefault(x => x.Name == targetValue);
+
+                    var objDependencyTargetType = objPropertyTarget != null
+                        ? objPropertyTarget.PropertyType.Resolve()
+                        : objFieldTarget?.FieldType.Resolve();
+
+                    if(objDependencyTargetType == null)
+                    {
+                        LogError("Couldn't result the dependency type");
+                        continue;
+                    }
+
+                    // Look for the target property on the member obj
+                    var destinationPropertyNamedArgument = attribute.Properties.FirstOrDefault(x => x.Name == "TargetProperty");
+                    var destinationPropertyName = destinationPropertyNamedArgument.Argument.Value?.ToString();
+
+                    // If no target property was specified use this property's name as the target on the decorated object (ala a decorated property)
+                    if (string.IsNullOrEmpty(destinationPropertyName)) destinationPropertyName = facadeProperty.Name;
+                    
+                    if (objDependencyTargetType.Properties.All(x => x.Name != destinationPropertyName))
+                    {
+                        LogError($"Target property {destinationPropertyName} on dependency of type {objDependencyTargetType.DeclaringType.Name} not found");
+                        continue;
+                    }
+
+                    var destinationProperty = objDependencyTargetType.Properties.First(x => x.Name == destinationPropertyName);
+
+                    // The property on the facade/decorator should have a setter
+                    if (facadeProperty.SetMethod == null)
+                    {
+                        LogError($"Property {facadeProperty.DeclaringType.FullName}.{facadeProperty.Name} has no setter, therefore it is not possible for the property to change, and thus should not be marked with [ReactiveDecorator]");
+                        continue;
+                    }
+
+                    // The property on the dependency should have a setter e.g. Dependency.SomeProperty = value;
+                    if (destinationProperty.SetMethod == null)
+                    {
+                        LogError($"Dependency object's property {destinationProperty.DeclaringType.FullName}.{destinationProperty.Name} has no setter, therefore it is not possible for the property to change, and thus should not be marked with [ReactiveDecorator]");
+                        continue;
+                    }
+
+                    // Remove old field (the generated backing field for the auto property)
+                    var oldField = (FieldReference)facadeProperty.GetMethod.Body.Instructions.Where(x => x.Operand is FieldReference).Single().Operand;
+                    var oldFieldDefinition = oldField.Resolve();
+                    targetType.Fields.Remove(oldFieldDefinition);
+
+                    // See if there exists an initializer for the auto-property
+                    var constructors = targetType.Methods.Where(x => x.IsConstructor);
+                    foreach (var constructor in constructors)
+                    {
+                        var fieldAssignment = constructor.Body.Instructions.SingleOrDefault(x => Equals(x.Operand, oldFieldDefinition) || Equals(x.Operand, oldField));
+                        if (fieldAssignment != null)
+                        {
+                            // Replace field assignment with a property set (the stack semantics are the same for both, 
+                            // so happily we don't have to manipulate the bytecode any further.)
+                            var setterCall = constructor.Body.GetILProcessor().Create(facadeProperty.SetMethod.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, facadeProperty.SetMethod);
+                            constructor.Body.GetILProcessor().Replace(fieldAssignment, setterCall);
+                        }
+                    }
+
+                    // Build out the getter which simply returns the value of the generated field
+                    facadeProperty.GetMethod.Body = new MethodBody(facadeProperty.GetMethod);
+                    facadeProperty.GetMethod.Body.Emit(il =>
+                    {
+                        il.Emit(OpCodes.Ldarg_0);                                   // this
+                        if (objPropertyTarget != null)
+                        {
+                            il.Emit(objPropertyTarget.GetMethod.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, objPropertyTarget.GetMethod);
+                        }
+                        else
+                        {
+                            il.Emit(OpCodes.Ldfld, objFieldTarget);
+                        }
+                        il.Emit(destinationProperty.GetMethod.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, destinationProperty.GetMethod);
+                        il.Emit(OpCodes.Ret);
+                    });
+
+                    TypeReference genericTargetType = targetType;
+                    if (targetType.HasGenericParameters)
+                    {
+                        var genericDeclaration = new GenericInstanceType(targetType);
+                        foreach (var parameter in targetType.GenericParameters)
+                        {
+                            genericDeclaration.GenericArguments.Add(parameter);
+                        }
+                        genericTargetType = genericDeclaration;
+                    }
+
+                    var methodReference = raisePropertyChangedMethod.MakeGenericMethod(genericTargetType);
+                    facadeProperty.SetMethod.Body = new MethodBody(facadeProperty.SetMethod);
+                    facadeProperty.SetMethod.Body.Emit(il =>
+                    {
+                        il.Emit(OpCodes.Ldarg_0);
+                        if (objPropertyTarget != null)
+                        {
+                            il.Emit(objPropertyTarget.GetMethod.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, objPropertyTarget.GetMethod);
+                        }
+                        else
+                        {
+                            il.Emit(OpCodes.Ldfld, objFieldTarget);
+                        }
+                        il.Emit(OpCodes.Ldarg_1);
+                        il.Emit(destinationProperty.SetMethod.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, destinationProperty.SetMethod);       // Set the nested property
+                        il.Emit(OpCodes.Ldarg_0);
+                        il.Emit(OpCodes.Ldstr, facadeProperty.Name);                // "PropertyName"
+                        il.Emit(OpCodes.Call, methodReference);                     // this.RaisePropertyChanged("PropertyName")
+                        il.Emit(OpCodes.Ret);                                       
+                    });
+                }
+            }
+        }
+    }
+}

--- a/ReactiveUI.Fody/ReactiveUI.Fody.csproj
+++ b/ReactiveUI.Fody/ReactiveUI.Fody.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ModuleWeaver.cs" />
     <Compile Include="ObservableAsPropertyWeaver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReactiveDependencyPropertyWeaver.cs" />
     <Compile Include="ReactiveUIPropertyWeaver.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUIFody.sln
+++ b/ReactiveUIFody.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.Fody", "ReactiveUI.Fody\ReactiveUI.Fody.csproj", "{CCACB6C3-4C59-4372-85D1-CDDCE0D26989}"
 EndProject
@@ -21,8 +21,8 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ReactiveUI.Fody.Helpers\ReactiveUI.Fody.Helpers.projitems*{1ca52110-be45-4c45-b709-28061077e2a5}*SharedItemsImports = 4
-		ReactiveUI.Fody.Helpers\ReactiveUI.Fody.Helpers.projitems*{8509509a-17c7-4cf0-84ad-5dd208446766}*SharedItemsImports = 4
 		ReactiveUI.Fody.Helpers\ReactiveUI.Fody.Helpers.projitems*{4433ff2e-3150-4d7f-be18-a2258799b79d}*SharedItemsImports = 13
+		ReactiveUI.Fody.Helpers\ReactiveUI.Fody.Helpers.projitems*{8509509a-17c7-4cf0-84ad-5dd208446766}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/ReactiveUIFodyAll.sln
+++ b/ReactiveUIFodyAll.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.Fody", "ReactiveUI.Fody\ReactiveUI.Fody.csproj", "{CCACB6C3-4C59-4372-85D1-CDDCE0D26989}"
 EndProject


### PR DESCRIPTION
Adds support for raising property change within an object, when this is a pass through update to an injected dependency or object contained within the class. See usage below using the decorator pattern as an example.
- Added new ReactiveDependencyPropertyWeaver which supports targeting properties one level deep on a named property or field.
- Added unit tests for decorator pattern and facades
- Updated ModuleWeaver to use new weaver

Sample Usage

``` C#
public class Thing : IThing
{
    [Reactive]
    public virtual string CoolProperty { get; set; }
}

public class DecoratedThing : Thing
{
    private Thing _thing;
    public DecoratedThing(Thing thing)
    {
        _thing = thing;
    }

    // BEFORE
    public override string CoolProperty
    {
        get { return _thing.CoolProperty; }
        set
        {
            _thing.CoolProperty = value;
            this.RaisePropertyChanged("CoolProperty");
        }
    }

    // AFTER
    [ReactiveDependency(nameof(_thing)]
    public override string CoolProperty { get; set; }
}
```
