### PR TITLE
Issue 41 - Raise Property Change on Expression Bodied Properties

### DIFF
--- a/ReactiveUI.Fody.Tests/Issues/Issue41Tests.cs
+++ b/ReactiveUI.Fody.Tests/Issues/Issue41Tests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using NUnit.Framework;
+using ReactiveUI.Fody.Helpers;
+
+namespace ReactiveUI.Fody.Tests.Issues
+{
+    [TestFixture]
+    public class Issue41Tests
+    {
+        [Test]
+        public void PropertyChangeNotificationRaisedForDerivedPropertyOnIntPropertySet()
+        {
+            // Arrange
+            var model = new TestModel();
+            var expectedInpcPropertyName = "DerivedProperty";
+            var receivedInpcPropertyNames = new List<string>();
+
+            var inpc = (INotifyPropertyChanged) model;
+            inpc.PropertyChanged += (sender, args) => receivedInpcPropertyNames.Add(args.PropertyName);
+
+            // Act
+            model.IntProperty = 5;
+
+            // Assert
+            Assert.IsTrue(receivedInpcPropertyNames.Contains(expectedInpcPropertyName));
+        }
+
+        [Test]
+        public void PropertyChangeNotificationRaisedOnStringPropertySet()
+        {
+            // Arrange
+            var model = new TestModel();
+            var expectedInpcPropertyName = "DerivedProperty";
+            var receivedInpcPropertyNames = new List<string>();
+
+            var inpc = (INotifyPropertyChanged) model;
+            inpc.PropertyChanged += (sender, args) => receivedInpcPropertyNames.Add(args.PropertyName);
+
+            // Act
+            model.StringProperty = "Foo";
+
+            // Assert
+            Assert.IsTrue(receivedInpcPropertyNames.Contains(expectedInpcPropertyName));
+        }
+
+        [Test]
+        public void PropertyChangeNotificationRaisedForDerivedPropertyAndAnotherExpressionBodiedPropertyOnIntPropertySet()
+        {
+            // Arrange
+            var model = new TestModel();
+            var expectedInpcPropertyName1 = "AnotherExpressionBodiedProperty";
+            var expectedInpcPropertyName2 = "DerivedProperty";
+            var receivedInpcPropertyNames = new List<string>();
+
+            var inpc = (INotifyPropertyChanged) model;
+            inpc.PropertyChanged += (sender, args) => receivedInpcPropertyNames.Add(args.PropertyName);
+
+            // Act
+            model.IntProperty = 5;
+
+            // Assert
+            Assert.IsTrue(receivedInpcPropertyNames.Contains(expectedInpcPropertyName1));
+            Assert.IsTrue(receivedInpcPropertyNames.Contains(expectedInpcPropertyName2));
+        }
+
+        [Test]
+        public void PropertyChangeNotificationRaisedForCombinedExpressionBodyPropertyWithAutoPropOnStringPropertySet()
+        {
+            // Arrange
+            var model = new TestModel();
+            var expectedInpcPropertyName = "CombinedExpressionBodyPropertyWithAutoProp";
+            var receivedInpcPropertyNames = new List<string>();
+
+            var inpc = (INotifyPropertyChanged)model;
+            inpc.PropertyChanged += (sender, args) => receivedInpcPropertyNames.Add(args.PropertyName);
+
+            // Act
+            model.StringProperty = "Foo";
+
+            // Assert
+            Assert.IsTrue(receivedInpcPropertyNames.Contains(expectedInpcPropertyName));
+        }
+
+        class TestModel : ReactiveObject
+        {
+            // Does not raise property change on itself
+            public int IntProperty { get; set; }
+
+            [Reactive]
+            // Raise Property Change on self to ensure this doesn't break existing [Reactive] weaving
+            public string StringProperty { get; set; }
+
+            [Reactive]
+            // Raise property change when either StringProperty or IntProperty are set
+            public string DerivedProperty => StringProperty + IntProperty;
+
+            [Reactive]
+            // Raise property change when IntProperty is set
+            public int AnotherExpressionBodiedProperty => IntProperty;
+
+            [Reactive]
+            public string CombinedExpressionBodyPropertyWithAutoProp => AnotherExpressionBodiedProperty + StringProperty;
+        } 
+    }
+}

--- a/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
+++ b/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Issues\Issue10Tests.cs" />
     <Compile Include="Issues\Issue13Tests.cs" />
     <Compile Include="Issues\Issue11Tests.cs" />
+    <Compile Include="Issues\Issue41Tests.cs" />
     <Compile Include="ObservableAsPropertyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactiveDependencyTests.cs" />

--- a/ReactiveUI.Fody/CecilExtensions.cs
+++ b/ReactiveUI.Fody/CecilExtensions.cs
@@ -126,6 +126,15 @@ namespace ReactiveUI.Fody
             return type.FullName == compareTo.FullName;
         }
 
+        public static bool IsExpressionBodiedProperty(this MethodDefinition method)
+        {
+            return method.Body.Instructions.Any(i =>
+            {
+                var operand = i.Operand as MethodDefinition;
+                return i.OpCode == OpCodes.Call && (operand?.IsGetter ?? false);
+            });
+        }
+
 /*
 
         public static IEnumerable<TypeDefinition> GetAllTypes(this ModuleDefinition module)


### PR DESCRIPTION
Updated the ReactiveUIPropertyWeaver to support expression bodied properties.
This is achieved by adding this.RaisePropertyChanged("ExpressionBodiedPropertyName") to the setter on dependent properties decorated with the [Reactive] attribute, dependent properties are calculated recursively, so given

```C#
[Reactive] public string Foo { get; set; }
[Reactive] public string Bar { get; set; }
public string Baz { get; set; }

[Reactive] public string FooBar => Foo + Bar;
[Reactive] public string FooBarHello => FooBar + "hello";
[Reactive] public string FooBarHelloBaz => FooBarHello + Baz;
[Reactive] public string BazHello => Baz + "hello";
```

**FooBar** will raise on **Foo** or **Bar** being set.
**FooBarHello** will raise on **Foo** or **Bar** being set
**FooBarHelloBaz** will raise on **Foo** or **Bar** being set, but not Baz as it's not decorated with the [Reactive] attribute
**BazHello** will throw an **error during build** as non of the dependent properties in the chain are decorated with the [Reactive] attribute.