### PR TITLE
Fix ObservableAsPropertyHelper of type long failing to compile

### DIFF
--- a/ReactiveUI.Fody.Tests/Issues/Issue47Tests.cs
+++ b/ReactiveUI.Fody.Tests/Issues/Issue47Tests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ReactiveUI.Fody.Helpers;
+
+namespace ReactiveUI.Fody.Tests.Issues
+{
+	public class Issue47Tests
+	{
+		/// <summary>
+		/// The "test" here is simply for these to compile
+		/// Tests ObservableAsPropertyWeaver.EmitDefaultValue
+		/// </summary>
+		class TestModel : ReactiveObject
+		{
+			public extern int IntProperty { [ObservableAsProperty] get; }
+			public extern double DoubleProperty { [ObservableAsProperty] get; }
+			public extern float FloatProperty { [ObservableAsProperty] get; }
+			public extern long LongProperty { [ObservableAsProperty] get; }
+		}
+	}
+}

--- a/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
+++ b/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Issues\Issue13Tests.cs" />
     <Compile Include="Issues\Issue11Tests.cs" />
     <Compile Include="Issues\Issue41Tests.cs" />
+    <Compile Include="Issues\Issue47Tests.cs" />
     <Compile Include="ObservableAsPropertyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactiveDependencyTests.cs" />

--- a/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
+++ b/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
@@ -105,7 +105,7 @@ namespace ReactiveUI.Fody
             }
             else if (type.CompareTo(ModuleDefinition.TypeSystem.Int64))
             {
-                il.Emit(OpCodes.Ldc_I8);
+                il.Emit(OpCodes.Ldc_I8, (long)0);
             }
             else if (type.CompareTo(ModuleDefinition.TypeSystem.Double))
             {


### PR DESCRIPTION
Fixes #47.

So the failing line in ReactiveUI.Fody was `ObservableAsPropertyWeaver.cs:107`, and [according to Microsoft's documentation](https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.ldc_i8(v=vs.110).aspx) the `Ldc_I8` opcode requires an argument. So I added that. 🙂 

I also added some "tests" for the four basic datatypes of `ObservableAsPropertyHelper`. The `long` version wouldn't have compiled with the latest package.